### PR TITLE
Improve the journal interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: c
 script: bash -ex .travis-ci.sh
 env:
   - OCAML_VERSION=4.02.0 OPAM_VERSION=1.2.0
+notifications:
+  slack: xseng:ge9mYWGZZGFQPv3LsBnQeFCR

--- a/lib/journal.ml
+++ b/lib/journal.ml
@@ -51,6 +51,7 @@ module Make
            error "In replay, failed to advance consumer: %s" msg;
            fail (Failure msg)
          | `Ok () ->
+           t.consumed <- Some position;
            (* wake up anyone stuck in a `Retry loop *)
            Lwt_condition.broadcast t.cvar ();
            return () )

--- a/lib/journal.mli
+++ b/lib/journal.mli
@@ -14,7 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make(Producer: S.PRODUCER)(Consumer: S.CONSUMER with type disk = Producer.disk)(Operation: S.CSTRUCTABLE) :
+module Make
+  (Producer: S.PRODUCER
+     with type position = int64)
+  (Consumer: S.CONSUMER
+     with type disk = Producer.disk
+      and type position = int64)
+  (Operation: S.CSTRUCTABLE) :
   S.JOURNAL
     with type disk := Producer.disk
      and type operation := Operation.t

--- a/lib/journal.mli
+++ b/lib/journal.mli
@@ -14,16 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make
-  (Producer: S.PRODUCER
-     with type position = int64)
-  (Consumer: S.CONSUMER
-     with type disk = Producer.disk
-      and type position = int64)
-  (Operation: S.CSTRUCTABLE) :
-  S.JOURNAL
-    with type disk := Producer.disk
-     and type operation := Operation.t
-(** Create a journal from a pair of producer and consumer rings connected
-    in loopback. XXX: it is possible to provide an unrelated set of rings
-    which is obviously nonsensical *)
+module Make(Block: S.BLOCK)(Operation: S.CSTRUCTABLE): S.JOURNAL
+  with type disk := Block.t
+   and type operation := Operation.t
+(** Create a journal from a block device. Descriptions of idempotent operations
+    may be pushed to the journal, and we guarantee to perform them at-least-once
+    in the order they were pushed provided the block device is available. If
+    the program crashes, the journal replay will be started when the program
+    restarts. *)

--- a/lib/ring.mli
+++ b/lib/ring.mli
@@ -22,10 +22,12 @@
     the client to either poll for updates or implement another out-of-band
     signalling mechanism. *)
 
-module Producer(B: S.BLOCK):
-  S.PRODUCER
+module Make(B: S.BLOCK): sig
+
+  module Producer: S.PRODUCER
     with type disk := B.t
 
-module Consumer(B: S.BLOCK):
-  S.CONSUMER
+  module Consumer: S.CONSUMER
     with type disk := B.t
+     and type position = Producer.position
+end

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -104,7 +104,9 @@ module type JOURNAL = sig
   val shutdown: t -> unit Lwt.t
   (** Shut down a journal replay thread *)
 
-  val push: t -> operation -> unit Lwt.t
+  val push: t -> operation -> (unit -> unit Lwt.t) Lwt.t
   (** Append an operation to the journal. When this returns, the operation will
-      be performed at-least-once before any later items are performed. *)
+      be performed at-least-once before any later items are performed.
+      If a client needs to wait for the operation to be completed then call
+      the returned thunk and wait for the resulting thread. *)
 end

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -14,10 +14,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type BLOCK =
-  V1.BLOCK
+module type BLOCK = V1.BLOCK
   with type 'a io = 'a Lwt.t
   and type page_aligned_buffer = Cstruct.t
+
+module type COMPARABLE = sig
+  type t
+  (** An item with a total ordering *)
+
+  val compare: t -> t -> [ `LessThan | `Equal | `GreaterThan ]
+  (** Compare two items *)
+end
 
 module type RING = sig
   type t
@@ -35,7 +42,9 @@ module type RING = sig
       after a detach will result in an [`Error _] *)
 
   type position with sexp_of
-  (** A position within the ring *)
+  (** The position within a stream *)
+
+  include COMPARABLE with type t := position
 
   val advance: t:t -> position:position -> unit -> [ `Ok of unit | `Error of string ] Lwt.t
   (** [advance t position] exposes the item associated with [position] to

--- a/unix/block_ring_unix.mli
+++ b/unix/block_ring_unix.mli
@@ -22,6 +22,8 @@
     up to the client to either poll for updates or implement another out-of-band
     signalling mechanism. *)
 
-module Producer: Shared_block.S.PRODUCER with type disk = string
+module Producer: Shared_block.S.PRODUCER
+  with type disk = string
 
-module Consumer: Shared_block.S.CONSUMER with type disk = string
+module Consumer: Shared_block.S.CONSUMER
+  with type disk = string


### PR DESCRIPTION
- clients can now block until the journaled operation actually completes, in addition to when the operation has been persisted to the journal
- Producer and Consumer modules are created as a pair, allowing more internals to remain hidden