### PR TITLE
test: improve coverage of the test case itself

### DIFF
--- a/lib_test/log.ml
+++ b/lib_test/log.ml
@@ -1,3 +1,5 @@
+(*BISECT-IGNORE-BEGIN*)
 let debug fmt = Printf.ksprintf (fun s -> print_endline s) fmt
 let info  fmt = Printf.ksprintf (fun s -> print_endline s) fmt
 let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
+(*BISECT-IGNORE-END*)


### PR DESCRIPTION
The test case ought to evolve into an example of expected usage, but it's very ugly at the moment, lacking proper combinators for handling errors (both transient and permanent)