### PR TITLE
Allow the journal entries to be batched, for efficient processing

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -29,7 +29,7 @@ Executable test
   MainIs:             test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, mirage-block-unix, shared-block-ring, cstruct, oUnit, io-page, io-page.unix, bisect
+  BuildDepends:       lwt, lwt.unix, mirage-block-unix, mirage-clock-unix, shared-block-ring, cstruct, oUnit, io-page, io-page.unix, bisect
 
 Test test
   Command:            ./test.native

--- a/lib/journal.ml
+++ b/lib/journal.ml
@@ -1,7 +1,7 @@
 open Lwt
 open Sexplib.Std
 
-module Alarm(Clock: S.CLOCK) = struct
+module Alarm(Time: S.TIME)(Clock: S.CLOCK) = struct
   type t = {
     mutable wake_up_at: float;
     mutable thread: unit Lwt.t option;
@@ -26,7 +26,7 @@ module Alarm(Clock: S.CLOCK) = struct
 
   let rec countdown t =
     let now = Clock.time () in
-    Clock.sleep (t.wake_up_at -. now)
+    Time.sleep (t.wake_up_at -. now)
     >>= fun () ->
     let now = Clock.time () in
     if now >= t.wake_up_at then begin
@@ -52,6 +52,7 @@ end
 module Make
   (Log: S.LOG)
   (Block: S.BLOCK)
+  (Time: S.TIME)
   (Clock: S.CLOCK)
   (Op: S.CSTRUCTABLE) = struct
 
@@ -60,7 +61,7 @@ module Make
   module R = Ring.Make(Log)(Block)(Op)
   open R
 
-  module Alarm = Alarm(Clock)
+  module Alarm = Alarm(Time)(Clock)
 
   type error = [ `Msg of string ]
   (*BISECT-IGNORE-BEGIN*)

--- a/lib/journal.mli
+++ b/lib/journal.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make(Log: S.LOG)(Block: S.BLOCK)(Operation: S.CSTRUCTABLE): S.JOURNAL
+module Make(Log: S.LOG)(Block: S.BLOCK)(Clock: S.CLOCK)(Operation: S.CSTRUCTABLE): S.JOURNAL
   with type disk := Block.t
    and type operation := Operation.t
 (** Create a journal from a block device. Descriptions of idempotent operations

--- a/lib/journal.mli
+++ b/lib/journal.mli
@@ -14,7 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make(Log: S.LOG)(Block: S.BLOCK)(Clock: S.CLOCK)(Operation: S.CSTRUCTABLE): S.JOURNAL
+module Make
+  (Log: S.LOG)
+  (Block: S.BLOCK)
+  (Time: S.TIME)
+  (Clock: S.CLOCK)
+  (Operation: S.CSTRUCTABLE):
+  S.JOURNAL
   with type disk := Block.t
    and type operation := Operation.t
 (** Create a journal from a block device. Descriptions of idempotent operations

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -131,13 +131,8 @@ module type CONSUMER = sig
       [position] which can be used to consume all the items at once. *)
 end
 
-module type CLOCK = sig
-  val time: unit -> float
-  (** [time ()] returns the number of seconds since Jan 1 1970 *)
-
-  val sleep: float -> unit Lwt.t
-  (** [sleep secs] blocks for [secs] seconds *)
-end
+module type CLOCK = V1.CLOCK
+module type TIME = V1_LWT.TIME
 
 module type JOURNAL = sig
   type t

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -24,8 +24,8 @@ module Lwt_result = struct
   let (>>=) m f = m >>= fun x -> f (get_ok x)
 end
 
-module Clock = struct
-  let time = Unix.gettimeofday
+module Time = struct
+  type 'a io = 'a Lwt.t
   let sleep = Lwt_unix.sleep
 end
 
@@ -215,7 +215,7 @@ let test_journal () =
 
     let open Lwt_result in
     Block.connect name >>= fun device ->
-    let module J = Shared_block.Journal.Make(Log)(Block)(Clock)(Op) in
+    let module J = Shared_block.Journal.Make(Log)(Block)(Time)(Clock)(Op) in
     let perform xs =
       List.iter (fun x ->
         assert (x = "hello")
@@ -246,7 +246,7 @@ let test_journal_replay () =
 
     let open Lwt_result in
     Block.connect name >>= fun device ->
-    let module J = Shared_block.Journal.Make(Log)(Block)(Clock)(Op) in
+    let module J = Shared_block.Journal.Make(Log)(Block)(Time)(Clock)(Op) in
     let t, u = Lwt.task () in
     let perform = function
       | [] -> return (`Ok ())
@@ -282,7 +282,7 @@ let test_journal_order () =
 
     let open Lwt_result in
     Block.connect name >>= fun device ->
-    let module J = Shared_block.Journal.Make(Log)(Block)(Clock)(Int) in
+    let module J = Shared_block.Journal.Make(Log)(Block)(Time)(Clock)(Int) in
 
     let counter = ref 0l in
     let last_flush = ref 0. in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -24,6 +24,11 @@ module Lwt_result = struct
   let (>>=) m f = m >>= fun x -> f (get_ok x)
 end
 
+module Clock = struct
+  let time = Unix.gettimeofday
+  let sleep = Lwt_unix.sleep
+end
+
 let find_unused_file () =
   (* Find a filename which doesn't exist *)
   let rec does_not_exist i =
@@ -210,7 +215,7 @@ let test_journal () =
 
     let open Lwt_result in
     Block.connect name >>= fun device ->
-    let module J = Shared_block.Journal.Make(Log)(Block)(Op) in
+    let module J = Shared_block.Journal.Make(Log)(Block)(Clock)(Op) in
     let perform xs =
       List.iter (fun x ->
         assert (x = "hello")
@@ -241,7 +246,7 @@ let test_journal_replay () =
 
     let open Lwt_result in
     Block.connect name >>= fun device ->
-    let module J = Shared_block.Journal.Make(Log)(Block)(Op) in
+    let module J = Shared_block.Journal.Make(Log)(Block)(Clock)(Op) in
     let t, u = Lwt.task () in
     let perform = function
       | [] -> return (`Ok ())
@@ -277,7 +282,7 @@ let test_journal_order () =
 
     let open Lwt_result in
     Block.connect name >>= fun device ->
-    let module J = Shared_block.Journal.Make(Log)(Block)(Int) in
+    let module J = Shared_block.Journal.Make(Log)(Block)(Clock)(Int) in
 
     let counter = ref 0l in
     let last_flush = ref 0. in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -336,4 +336,4 @@ let _ =
     "test journal replay" >:: test_journal_replay;
     "test journal order" >:: test_journal_order;
   ] @ test_push_pops in
-  run_test_tt suite
+  run_test_tt_main suite

--- a/opam
+++ b/opam
@@ -16,6 +16,7 @@ depends: [
   "ounit"
   "mirage-types"
   "mirage-block-unix"
+  "mirage-clock-unix"
   "sexplib"
   "io-page"
   "io-page-unix"


### PR DESCRIPTION
If we supply an interval, then on every push a timer will be started.
Journal entries will be processed when the timer expires. If the journal
is full then the timer is immediately set to 0 so the entries are
flushed immediately.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>