### PR TITLE
Fix a data corruption issue

### DIFF
--- a/.travis.oasis
+++ b/.travis.oasis
@@ -12,7 +12,7 @@ Library shared_block
   CompiledObject:     best
   Path:               lib
   Findlibname:        shared-block-ring
-  Modules:            Ring, Journal, S, Monad, Result
+  Modules:            Ring, Journal, EraseBlock, S, Monad, Result
   BuildDepends:       cstruct, lwt, mirage-types, io-page, sexplib, sexplib.syntax, bisect
 
 Executable "shared-block-ring"

--- a/_oasis
+++ b/_oasis
@@ -18,7 +18,7 @@ Library shared_block
   CompiledObject:     best
   Path:               lib
   Findlibname:        shared-block-ring
-  Modules:            Ring, Journal, S, Monad, Result
+  Modules:            Ring, Journal, EraseBlock, S, Monad, Result
   BuildDepends:       cstruct, lwt, mirage-types, io-page, sexplib, sexplib.syntax
 
 Executable "shared-block-ring"

--- a/example/main.ml
+++ b/example/main.ml
@@ -96,6 +96,11 @@ let create filename =
     >>= function
     | `Error x -> fail (Failure (Printf.sprintf "Failed to connect to %s" filename))
     | `Ok disk ->
+    let module Eraser = Shared_block.EraseBlock.Make(Block) in
+    Eraser.erase ~pattern:(Printf.sprintf "shared-block-ring/example/main.ml erased the %s volume; " filename) disk
+    >>= function
+    | `Error _ -> fail (Failure (Printf.sprintf "Failed to erase %s" filename))
+    | `Ok () ->
     Producer.create ~disk >>|= fun _ -> return () in
   try
     `Ok (Lwt_main.run t)

--- a/lib/eraseBlock.ml
+++ b/lib/eraseBlock.ml
@@ -1,0 +1,53 @@
+(*
+ * Copyright (C) 2009-2015 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Lwt
+
+let block_error = function
+  | `Unknown x -> `Error (`Msg x)
+  | `Unimplemented -> `Error (`Msg "unimplemented")
+  | `Is_read_only -> `Error (`Msg "device is read-only")
+  | `Disconnected -> `Error (`Msg "disconnected")
+
+module IO = struct
+  let ( >>= ) m f = m >>= function
+  | `Error e -> return (block_error e)
+  | `Ok x -> f x
+end
+
+let block_size_pages = 1024
+
+module Make(B: S.BLOCK) = struct
+  let erase ?(pattern = "This block has been erased by mirage-block-volume/lib/eraseBlock.ml") t =
+    let open Lwt in
+    B.get_info t
+    >>= fun info ->
+    let pages = Io_page.get block_size_pages in
+    let buffer = Io_page.to_cstruct pages in
+    for i = 0 to Cstruct.len buffer - 1 do
+      Cstruct.set_char buffer i (pattern.[i mod (String.length pattern)])
+    done;
+    let open IO in
+    let rec loop n =
+      if n = info.B.size_sectors
+      then return (`Ok ())
+      else
+        let buffer_in_sectors = Cstruct.len buffer / info.B.sector_size in
+        let needed = Int64.to_int (min (Int64.sub info.B.size_sectors n) (Int64.of_int buffer_in_sectors)) in
+        let towrite = Cstruct.sub buffer 0 (needed * info.B.sector_size) in
+        B.write t n [ towrite ]
+        >>= fun () ->
+        loop (Int64.(add n (of_int needed))) in
+    loop 0L
+end

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -115,6 +115,15 @@ let test_push_pop length batch () =
     (* check debug_info works *)
     let _ = Producer.debug_info producer in
     let _ = Consumer.debug_info consumer in
+
+    let finished = ref false in
+    let rec spin () =
+      if !finished then return () else begin
+        Producer.state producer >>= fun _ ->
+        spin ()
+      end in
+    let spinner = spin () in
+
     let rec loop = function
       | 0 -> return ()
       | n ->
@@ -146,6 +155,8 @@ let test_push_pop length batch () =
     (* push/pop 2 * the number of sectors to guarantee we experience some wraparound *)
     let open Lwt in
     loop Int64.(to_int (mul 2L (div size 512L))) >>= fun () ->
+    finished := true;
+
     (* count how many items we can push in total *)
     let rec loop acc =
       let open Lwt in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -232,7 +232,8 @@ let test_journal () =
     let module J = Shared_block.Journal.Make(Log)(Block)(Time)(Clock)(Op) in
     let perform xs =
       List.iter (fun x ->
-        assert (x = "hello")
+        if x <> "hello"
+        then failwith (Printf.sprintf "[%s]<>\"hello\"" (String.escaped x))
       ) xs;
       return (`Ok ()) in
     J.start ~client:"test" ~name:"test_journal" device perform

--- a/opam
+++ b/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt"
   "ocamlfind"
   "ounit"
-  "mirage-types"
+  "mirage-types-lwt"
   "mirage-block-unix"
   "mirage-clock-unix"
   "sexplib"


### PR DESCRIPTION
It should now be safe to call `state` in parallel with `push`, `pop` etc. Previously the `state` call would use the same temporary buffer as `push` and `pop`, causing the producer or consumer sector to be written to the data portion of the ring.