### PR TITLE
Redo_log: add a `flush` API to flush immediately

### DIFF
--- a/lib/s.ml
+++ b/lib/s.ml
@@ -174,7 +174,10 @@ module type JOURNAL = sig
   val shutdown: t -> unit Lwt.t
   (** Shut down a journal replay thread *)
 
-  type waiter = unit -> unit Lwt.t
+  type waiter = {
+    flush: unit -> unit;
+    sync: unit -> unit Lwt.t
+  }
 
   val push: t -> operation -> waiter result Lwt.t
   (** Append an operation to the journal. When this returns, the operation will

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -241,7 +241,7 @@ let test_journal () =
     J.push j "hello"
     >>= fun w ->
     let open Lwt in
-    w ()
+    w.J.sync ()
     >>= fun () ->
     J.push j (String.create (Int64.to_int size))
     >>= fun t ->
@@ -324,7 +324,7 @@ let test_journal_order () =
     loop 0l
     >>= fun w ->
     let open Lwt in
-    w ()
+    w.J.sync ()
     >>= fun () ->
     J.shutdown j in
   Lwt_main.run t


### PR DESCRIPTION
The `push` function now returns a record of

- `flush`: trigger an immediate flush
- `sync`: block until the flush is complete

Note this is a backwards-incompatible change.

Signed-off-by: David Scott <dave.scott@citrix.com>