### PR TITLE
Remove the blocking log functions from the Log module

### DIFF
--- a/example/main.ml
+++ b/example/main.ml
@@ -16,10 +16,11 @@ open Lwt
 let project_url = "http://github.com/djs55/shared-block-ring"
 
 module Log = struct
-  let debug fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-  let info  fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-  let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-  let trace _ = ()
+  let debug fmt = Lwt_log.debug_f fmt
+  let info fmt = Lwt_log.info_f fmt
+  let error fmt = Lwt_log.error_f fmt
+
+  let trace _ = Lwt.return ()
 end
 
 module R = Shared_block.Ring.Make(Log)(Block)(struct

--- a/lib/journal.ml
+++ b/lib/journal.ml
@@ -117,7 +117,8 @@ module Make
       ) >>= function
     | `Ok x -> return (`Ok x)
     | `Error (`Msg x) ->
-      error "Failed to process journal item: %s" x;
+      error "Failed to process journal item: %s" x
+      >>= fun () ->
       return (`Error (`Msg x))
 
   let replay t () =
@@ -127,7 +128,8 @@ module Make
     >>|= fun (position, items) ->
     (* Note we want to apply the items in the original order *)
     let items = List.rev items in
-    info "There are %d items in the journal to replay" (List.length items);
+    info "There are %d items in the journal to replay" (List.length items)
+    >>= fun () ->
     perform t items
     >>|= fun () ->
     Consumer.advance ~t:t.c ~position

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -42,11 +42,11 @@ type traced_operation = [
 type traced_operation_list = traced_operation list with sexp
 
 module type LOG = sig
-  val debug : ('a, unit, string, unit) format4 -> 'a
-  val info  : ('a, unit, string, unit) format4 -> 'a
-  val error : ('a, unit, string, unit) format4 -> 'a
+  val debug : ('a, unit, string, unit Lwt.t) format4 -> 'a
+  val info : ('a, unit, string, unit Lwt.t) format4 -> 'a
+  val error : ('a, unit, string, unit Lwt.t) format4 -> 'a
 
-  val trace: traced_operation list -> unit
+  val trace: traced_operation list -> unit Lwt.t
 end
 
 module type RING = sig

--- a/lib_test/log.ml
+++ b/lib_test/log.ml
@@ -1,10 +1,12 @@
 (*BISECT-IGNORE-BEGIN*)
-let debug fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-let info  fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
+let debug fmt = Lwt_log.debug_f fmt
+let info  fmt = Lwt_log.info_f fmt
+let error fmt = Lwt_log.error_f fmt
 let verbose = ref false
 let trace list =
   if !verbose
-  then info "%s" (Sexplib.Sexp.to_string (Shared_block.S.sexp_of_traced_operation_list list))
-  else ()
+  then begin
+    info "%s" (Sexplib.Sexp.to_string (Shared_block.S.sexp_of_traced_operation_list list));
+    Lwt.return ()
+  end else Lwt.return ()
 (*BISECT-IGNORE-END*)


### PR DESCRIPTION
Make all of the Log functions return Lwt threads

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>