### PR TITLE
Build in the MirageOS 3 package universe.

### DIFF
--- a/.travis.oasis
+++ b/.travis.oasis
@@ -13,7 +13,7 @@ Library shared_block
   Path:               lib
   Findlibname:        shared-block-ring
   Modules:            Ring, Journal, EraseBlock, S, Monad
-  BuildDepends:       cstruct, lwt, mirage-types, io-page, sexplib, ppx_sexp_conv, bisect_ppx, result
+  BuildDepends:       cstruct, lwt, mirage-types, io-page, sexplib, ppx_sexp_conv, bisect_ppx, result, duration, rresult
 
 Executable "shared-block-ring"
   CompiledObject:     best

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: cp .travis.oasis _oasis && bash -ex .travis-opam.sh && bash -ex .coveralls.sh
+script: cp .travis.oasis _oasis && bash -ex .travis-opam.sh # && bash -ex .coveralls.sh
+sudo: required
 env:
-  - OCAML_VERSION=4.02 OPAM_VERSION=1.2.0
+  global:
+  - EXTRA_REMOTES="https://github.com/yomimono/mirage-dev.git#block-errors"
+  matrix:
+  - OCAML_VERSION=4.02
+  - OCAML_VERSION=4.03
+  - OCAML_VERSION=4.04
 notifications:
   slack: xseng:ge9mYWGZZGFQPv3LsBnQeFCR

--- a/_oasis
+++ b/_oasis
@@ -19,7 +19,7 @@ Library shared_block
   Path:               lib
   Findlibname:        shared-block-ring
   Modules:            Ring, Journal, EraseBlock, S, Monad
-  BuildDepends:       cstruct, lwt, mirage-types, io-page, sexplib, ppx_sexp_conv, result
+  BuildDepends:       cstruct, lwt, mirage-types, io-page, sexplib, ppx_sexp_conv, result, duration, rresult
 
 Executable "shared-block-ring"
   CompiledObject:     best

--- a/example/main.ml
+++ b/example/main.ml
@@ -46,10 +46,7 @@ let (>>|=) = bind
 
 let produce filename interval =
   let t =
-    Block.connect filename
-    >>= function
-    | `Error x -> fail (Failure (Printf.sprintf "Failed to open %s" filename))
-    | `Ok disk ->
+    Block.connect filename >>= fun disk ->
     Producer.attach ~disk
     >>|= fun p ->
     let rec loop () =
@@ -68,14 +65,11 @@ let produce filename interval =
   try
     `Ok (Lwt_main.run t)
   with e ->
-    `Error(false, Printexc.to_string e)
+    `Error (false, Printexc.to_string e)
 
 let consume filename interval =
   let t =
-    Block.connect filename
-    >>= function
-    | `Error x -> fail (Failure (Printf.sprintf "Failed to open %s" filename))
-    | `Ok disk ->
+    Block.connect filename >>= fun disk ->
     Consumer.attach ~disk
     >>|= fun c ->
     let rec loop () =
@@ -94,10 +88,7 @@ let consume filename interval =
 
 let create filename =
   let t =
-    Block.connect filename
-    >>= function
-    | `Error x -> fail (Failure (Printf.sprintf "Failed to connect to %s" filename))
-    | `Ok disk ->
+    Block.connect filename >>= fun disk ->
     let module Eraser = Shared_block.EraseBlock.Make(Block) in
     Eraser.erase ~pattern:(Printf.sprintf "shared-block-ring/example/main.ml erased the %s volume; " filename) disk
     >>= function
@@ -111,10 +102,7 @@ let create filename =
 
 let diagnostics filename =
   let t =
-    Block.connect filename
-    >>= function
-    | `Error x -> fail (Failure (Printf.sprintf "Failed to connect to %s" filename))
-    | `Ok disk ->
+    Block.connect filename >>= fun disk ->
     Consumer.attach ~disk
     >>|= fun c ->
     let rec loop ?from () =
@@ -135,10 +123,7 @@ let diagnostics filename =
 
 let suspend filename =
   let t =
-    Block.connect filename
-    >>= function
-    | `Error x -> fail (Failure (Printf.sprintf "Failed to connect to %s" filename))
-    | `Ok disk ->
+    Block.connect filename >>= fun disk ->
     Consumer.attach ~disk
     >>|= fun c ->
     (fun () -> Consumer.suspend c)
@@ -151,10 +136,7 @@ let suspend filename =
 
 let resume filename =
   let t =
-    Block.connect filename
-    >>= function
-    | `Error x -> fail (Failure (Printf.sprintf "Failed to connect to %s" filename))
-    | `Ok disk ->
+    Block.connect filename >>= fun disk ->
     Consumer.attach ~disk
     >>|= fun c ->
     (fun () -> Consumer.resume c)

--- a/lib/ring.ml
+++ b/lib/ring.ml
@@ -82,19 +82,19 @@ module Common(Log: S.LOG)(B: S.BLOCK) = struct
   let ( >>*= ) m f =
     let open Lwt in
     m >>= function
-    | `Ok x -> f x
+    | Ok x -> f x
     (* These fatal errors from the block layer indicate a software bug:
        code missing, device openeed read-only, or device prematurely
        disconnected. The best we can do is to propagate an unhandleable
        error upwards to where it can be logged, and the process / thread
        can exit. *)
-    | `Error `Unimplemented -> return (Error (`Msg "BLOCK function is unimplemented"))
-    | `Error `Is_read_only -> return (Error (`Msg "BLOCK device is read-only"))
-    | `Error `Disconnected -> return (Error (`Msg "BLOCK device has already disconnected"))
+    | Error `Unimplemented -> return (Error (`Msg "BLOCK function is unimplemented"))
+    | Error `Is_read_only -> return (Error (`Msg "BLOCK device is read-only"))
+    | Error `Disconnected -> return (Error (`Msg "BLOCK device has already disconnected"))
     (* This is a bad error which includes both permanent failures and
        I/O errors which could be recoverable. We will assume the error
        can be recovered and invite the upper layer to retry. *)
-    | `Error (`Unknown x) -> return (Error `Retry)
+    | Error (`Msg x) -> return (Error `Retry)
 
   let trace list =
     Lwt.bind (Log.trace list) (fun () -> Lwt.return (Ok ()))

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -148,7 +148,10 @@ module type CONSUMER = sig
       [position] which can be used to consume all the items at once. *)
 end
 
-module type CLOCK = V1.CLOCK
+module type CLOCK = sig
+  include V1.MCLOCK
+  val connect : unit -> t Lwt.t
+end
 module type TIME = V1_LWT.TIME
 
 module type JOURNAL = sig
@@ -167,7 +170,7 @@ module type JOURNAL = sig
   val open_error : 'a result -> ('a, [> error]) Result.result
   val error_to_msg : 'a result -> ('a, msg) Result.result
 
-  val start: ?name:string -> ?client:string -> ?flush_interval:float -> ?retry_interval:float -> disk -> (operation list -> unit result Lwt.t) -> t result Lwt.t
+  val start: ?name:string -> ?client:string -> ?flush_interval:int64 -> ?retry_interval:int64 -> disk -> (operation list -> unit result Lwt.t) -> t result Lwt.t
   (** Start a journal replay thread on a given disk, with the given processing
       function which will be applied at-least-once to every item in the journal.
       If a [flush_interval] is provided then every push will start a timer

--- a/opam
+++ b/opam
@@ -31,4 +31,6 @@ depends: [
   "bisect_ppx"
   "oasis"
   "result"
+  "rresult"
+  "duration"
 ]


### PR DESCRIPTION
* use MCLOCK instead of the deprecated CLOCK
* use int64s representing nanoseconds for alarm/TIME (and Duration to convert when necessary)
* use BLOCK modules that return result types
* expect a BLOCK.connect which raises on failure