### PR TITLE
Update for safe-string and the lwt/lwt_log splitup

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -27,7 +27,7 @@ Executable "shared-block-ring"
   MainIs:             main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, mirage-block-unix, shared-block-ring, cstruct, oUnit, io-page, io-page-unix, cmdliner
+  BuildDepends:       lwt, lwt.unix, lwt_log, mirage-block-unix, shared-block-ring, cstruct, oUnit, io-page, io-page-unix, cmdliner
 
 Executable test
   CompiledObject:     best
@@ -35,7 +35,7 @@ Executable test
   MainIs:             test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, mirage-block-unix, mirage-clock-unix, shared-block-ring, cstruct, oUnit, io-page, io-page-unix
+  BuildDepends:       lwt, lwt.unix, lwt_log, mirage-block-unix, mirage-clock-unix, shared-block-ring, cstruct, oUnit, io-page, io-page-unix
 
 Test test
   Command:            ./test.native

--- a/lib/ring.ml
+++ b/lib/ring.ml
@@ -138,9 +138,9 @@ module Common(Log: S.LOG)(B: S.BLOCK) = struct
     let open Lwt_read_error in
     (* check for magic, initialise if not found *)
     B.read device sector_signature [ sector ] >>= fun () ->
-    let magic' = String.make (String.length magic) '\000' in
-    Cstruct.blit_to_string sector 0 magic' 0 (String.length magic');
-    return (magic = magic')
+    let magic' = Bytes.make (String.length magic) '\000' in
+    Cstruct.blit_to_bytes sector 0 magic' 0 (Bytes.length magic');
+    return (Bytes.unsafe_to_string magic' = magic)
 
   let create device info sector =
     let open ResultM in
@@ -351,7 +351,7 @@ module Producer = struct
   let unsafe_write (t:t) item =
     let open C in
     let open ResultM in
-    let sector = alloc t.info.Mirage_block.sector_size in
+    let _sector = alloc t.info.Mirage_block.sector_size in
     (* add a 4 byte header of size, and round up to the next 4-byte offset *)
     let needed_bytes = Int64.(logand (lognot 3L) (add 7L (of_int (Cstruct.len item)))) in
     let first_sector = Int64.(div t.producer.producer (of_int t.info.Mirage_block.sector_size)) in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -109,7 +109,7 @@ let test_push_pop length batch () =
     >>= fun name ->
 
     let payload = "All work and no play makes Dave a dull boy.\n" in
-    let toobig = String.create Int64.(to_int size) in
+    let toobig = Bytes.create Int64.(to_int size) in
     Block.connect name >>= fun disk ->
     let open Lwt_result in
     Producer.create ~disk () >>= fun () ->
@@ -136,7 +136,7 @@ let test_push_pop length batch () =
         let rec push = function
         | 0 -> return ()
         | m ->
-          Producer.push ~t:producer ~item:toobig () >>= fun r ->
+          Producer.push ~t:producer ~item:(Bytes.unsafe_to_string toobig) () >>= fun r ->
           ignore(get_error r);
           Producer.push ~t:producer ~item:payload () >>= fun r ->
           let position = get_ok r in
@@ -291,7 +291,7 @@ let test_journal () =
     let open Lwt in
     w.J.sync ()
     >>= fun () ->
-    J.push j (String.create (Int64.to_int size))
+    J.push j (Bytes.unsafe_to_string @@ Bytes.create (Int64.to_int size))
     >>= fun t ->
     ignore(get_error t);
     J.shutdown j

--- a/opam
+++ b/opam
@@ -21,6 +21,7 @@ depends: [
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "lwt"
+  "lwt_log"
   "ocamlfind"
   "ounit"
   "mirage-types-lwt" {>= "3.0.0"}


### PR DESCRIPTION
See also https://github.com/ocaml/opam-repository/pull/11708

I have not enabled -safe-string by default as it can break code that use the package but do not have safe-string enabled on the whole codebase