### PR TITLE
ci: properly set up environment to send coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: ["4.12.0", "4.06.0"]
+        # Test a single version of ocaml, OCaml-CI tests the rest
+        ocaml-version: ["4.12.0"]
         operating-system: [ubuntu-latest]
 
     runs-on: ${{ matrix.operating-system }}
@@ -37,3 +38,6 @@ jobs:
 
       - name: Upload coverage
         run: opam exec -- bisect-ppx-report send-to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
Test only the latest version of ocaml on github actions, the other
versions are tested using OCaml-CI, which is faster.

Fixes #34